### PR TITLE
Fix: UCI stop command does not interrupt search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Lozza's net was booted from ```quiet_labeled.epd``` and ```lichess-big3-resolved
 
 ## Limitations
 
-Lozza does not support the ```stop``` command or multi-threading.
+Lozza does not support multi-threading.
 
 ## Tweaking Lozza
 

--- a/lozza.js
+++ b/lozza.js
@@ -798,7 +798,7 @@ function addKiller (node, score, move) {
 
 }
 
-function go (maxPly) {
+async function go (maxPly) {
 
   let bestMoveStr = '';
   let alpha       = 0;
@@ -809,6 +809,13 @@ function go (maxPly) {
   let reported    = 0;
 
   multiPVMoves = [];
+
+  while (statsSearching)
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+  statsTimeOut   = 0;
+  statsStop      = 0;
+  statsSearching = 1;
 
   for (let ply=1; ply <= maxPly; ply++) {
     // id
@@ -888,18 +895,34 @@ function go (maxPly) {
         break;
 
       }
-      
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      if (statsStop) {
+        statsTimeOut = 1;
+        break;
+      }
+
     }
-    
+
     if (statsTimeOut)
       break;
-    
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    if (statsStop) {
+      statsTimeOut = 1;
+      break;
+    }
+
   }
 
   if (reported === 0)
     report(statsBestScore, depth || 1, '');
 
   bestMoveStr = formatMove(statsBestMove);
+
+  statsSearching = 0;
 
   uciSend('bestmove', bestMoveStr);
 
@@ -4062,6 +4085,8 @@ let statsTimeOut   = 0;
 let statsSelDepth  = 0;
 let statsBestMove  = 0;
 let statsBestScore = 0;
+let statsStop      = 0;
+let statsSearching = 0;
 
 let multiPV      = 1;
 let multiPVMoves = [];
@@ -4079,11 +4104,20 @@ function initStats () {
   statsBestMove  = 0;
   statsBestScore = 0;
 
+  // statsStop not reset here - see go()
+
 }
 
 // checkTime
 
 function checkTime () {
+
+  if (statsStop) {
+
+    statsTimeOut = 1;
+    return;
+
+  }
 
   if (statsBestMove && statsMoveTime > 0 && ((now() - statsStartTime) >= statsMoveTime))
 
@@ -4217,7 +4251,7 @@ const PERFTFENS = [
   ['fen r6r/1P4P1/2kPPP2/8/8/3ppp2/1p4p1/R3K2R                  w KQ   -  0 1', 6, 975944981, 'ob5       ']
 ];
 
-function bench (depth) {
+async function bench (depth) {
 
   depth = depth || BENCH_DEPTH;
 
@@ -4234,11 +4268,11 @@ function bench (depth) {
       //process.stdout.write(i.toString() + '\r');
 
     newGame();
-    uciExec('position fen ' + fen);
-    uciExec('go depth ' + depth);
-        
+    await uciExec('position fen ' + fen);
+    await uciExec('go depth ' + depth);
+
     nodes += statsNodes;
-      
+
   }
         
   const elapsed = now() - start;
@@ -4550,7 +4584,7 @@ function dgPlayMove (move) {
 // positions written; 0 means the game was discarded.
 //
 
-function dgPlayGame (fd) {
+async function dgPlayGame (fd) {
 
   const buf = dgGameBuf;
 
@@ -4603,7 +4637,7 @@ function dgPlayGame (fd) {
 
     statsMaxNodes = DG_SEARCH_NODES;
 
-    go(MAX_PLY);
+    await go(MAX_PLY);
 
     let best = statsBestMove;
 
@@ -4693,7 +4727,7 @@ function dgEta (ms) {
 
 // datagen
 
-function datagen (directory, targetPositions) {
+async function datagen (directory, targetPositions) {
 
   dgSeedRng();
 
@@ -4724,7 +4758,7 @@ function datagen (directory, targetPositions) {
 
   while (totalPositions < targetPositions) {
 
-    totalPositions += dgPlayGame(fd);
+    totalPositions += await dgPlayGame(fd);
     totalGames++;
 
     const timeNow = Date.now();
@@ -4824,7 +4858,7 @@ function uciGetArr (tokens, key, to) {
 
 // uciExec
 
-function uciExec (commands) {
+async function uciExec (commands) {
 
   const cmdList = commands.split('\n');
 
@@ -4856,7 +4890,10 @@ function uciExec (commands) {
       case 'position':
       case 'p': {
         // position
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         if (ttSize == 1) {
           uciSend('info do a ucinewgame or setoption name hash command first');
           break;
@@ -4894,7 +4931,10 @@ function uciExec (commands) {
       case 'go':
       case 'g': {
         // go
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         if (ttSize == 1) {
           uciSend('info do a ucinewgame or setoption name hash command first');
           break;
@@ -4956,7 +4996,7 @@ function uciExec (commands) {
             statsMoveTime = 1;
         }
         
-        go(depth);
+        await go(depth);
         break;
         
       }
@@ -4998,9 +5038,12 @@ function uciExec (commands) {
       }
 
       case 'stop': {
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         break;
-        
+
       }
 
       case 'uci': {
@@ -5052,7 +5095,7 @@ function uciExec (commands) {
       case 'bench':
       case 'h': {
 
-        bench(uciGetInt(tokens, cmd, 0));
+        await bench(uciGetInt(tokens, cmd, 0));
         break;
         
       }
@@ -5086,7 +5129,7 @@ function uciExec (commands) {
           break;
         }
 
-        datagen(tokens[1], target);
+        await datagen(tokens[1], target);
 
         break;
 
@@ -5273,9 +5316,11 @@ initOnce();
 const rootNode = nodes[0];
 
 if (nodeHost && process.argv.length > 2) {
-  for (let i=2; i < process.argv.length; i++)
-    uciExec(process.argv[i]);
-  process.exit(0);
+  (async () => {
+    for (let i=2; i < process.argv.length; i++)
+      await uciExec(process.argv[i]);
+    process.exit(0);
+  })();
 }
 
 if (nodeHost) {

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -232,7 +232,7 @@ function dgPlayMove (move) {
 // positions written; 0 means the game was discarded.
 //
 
-function dgPlayGame (fd) {
+async function dgPlayGame (fd) {
 
   const buf = dgGameBuf;
 
@@ -285,7 +285,7 @@ function dgPlayGame (fd) {
 
     statsMaxNodes = DG_SEARCH_NODES;
 
-    go(MAX_PLY);
+    await go(MAX_PLY);
 
     let best = statsBestMove;
 
@@ -375,7 +375,7 @@ function dgEta (ms) {
 
 // datagen
 
-function datagen (directory, targetPositions) {
+async function datagen (directory, targetPositions) {
 
   dgSeedRng();
 
@@ -406,7 +406,7 @@ function datagen (directory, targetPositions) {
 
   while (totalPositions < targetPositions) {
 
-    totalPositions += dgPlayGame(fd);
+    totalPositions += await dgPlayGame(fd);
     totalGames++;
 
     const timeNow = Date.now();

--- a/src/go.js
+++ b/src/go.js
@@ -1,4 +1,4 @@
-function go (maxPly) {
+async function go (maxPly) {
 
   let bestMoveStr = '';
   let alpha       = 0;
@@ -9,6 +9,13 @@ function go (maxPly) {
   let reported    = 0;
 
   multiPVMoves = [];
+
+  while (statsSearching)
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+  statsTimeOut   = 0;
+  statsStop      = 0;
+  statsSearching = 1;
 
   for (let ply=1; ply <= maxPly; ply++) {
     // id
@@ -88,18 +95,34 @@ function go (maxPly) {
         break;
 
       }
-      
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      if (statsStop) {
+        statsTimeOut = 1;
+        break;
+      }
+
     }
-    
+
     if (statsTimeOut)
       break;
-    
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    if (statsStop) {
+      statsTimeOut = 1;
+      break;
+    }
+
   }
 
   if (reported === 0)
     report(statsBestScore, depth || 1, '');
 
   bestMoveStr = formatMove(statsBestMove);
+
+  statsSearching = 0;
 
   uciSend('bestmove', bestMoveStr);
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,11 @@ initOnce();
 const rootNode = nodes[0];
 
 if (nodeHost && process.argv.length > 2) {
-  for (let i=2; i < process.argv.length; i++)
-    uciExec(process.argv[i]);
-  process.exit(0);
+  (async () => {
+    for (let i=2; i < process.argv.length; i++)
+      await uciExec(process.argv[i]);
+    process.exit(0);
+  })();
 }
 
 if (nodeHost) {

--- a/src/tc.js
+++ b/src/tc.js
@@ -6,6 +6,8 @@ let statsTimeOut   = 0;
 let statsSelDepth  = 0;
 let statsBestMove  = 0;
 let statsBestScore = 0;
+let statsStop      = 0;
+let statsSearching = 0;
 
 let multiPV      = 1;
 let multiPVMoves = [];
@@ -23,11 +25,20 @@ function initStats () {
   statsBestMove  = 0;
   statsBestScore = 0;
 
+  // statsStop not reset here - see go()
+
 }
 
 // checkTime
 
 function checkTime () {
+
+  if (statsStop) {
+
+    statsTimeOut = 1;
+    return;
+
+  }
 
   if (statsBestMove && statsMoveTime > 0 && ((now() - statsStartTime) >= statsMoveTime))
 

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,4 +1,4 @@
-function bench (depth) {
+async function bench (depth) {
 
   depth = depth || BENCH_DEPTH;
 
@@ -15,9 +15,9 @@ function bench (depth) {
       //process.stdout.write(i.toString() + '\r');
 
     newGame();
-    uciExec('position fen ' + fen);
-    uciExec('go depth ' + depth);
-        
+    await uciExec('position fen ' + fen);
+    await uciExec('go depth ' + depth);
+
     nodes += statsNodes;
       
   }

--- a/src/uci.js
+++ b/src/uci.js
@@ -70,7 +70,7 @@ function uciGetArr (tokens, key, to) {
 
 // uciExec
 
-function uciExec (commands) {
+async function uciExec (commands) {
 
   const cmdList = commands.split('\n');
 
@@ -102,7 +102,10 @@ function uciExec (commands) {
       case 'position':
       case 'p': {
         // position
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         if (ttSize == 1) {
           uciSend('info do a ucinewgame or setoption name hash command first');
           break;
@@ -140,7 +143,10 @@ function uciExec (commands) {
       case 'go':
       case 'g': {
         // go
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         if (ttSize == 1) {
           uciSend('info do a ucinewgame or setoption name hash command first');
           break;
@@ -202,7 +208,7 @@ function uciExec (commands) {
             statsMoveTime = 1;
         }
         
-        go(depth);
+        await go(depth);
         break;
         
       }
@@ -244,9 +250,12 @@ function uciExec (commands) {
       }
 
       case 'stop': {
-        
+
+        if (statsSearching)
+          statsStop = 1;
+
         break;
-        
+
       }
 
       case 'uci': {
@@ -298,7 +307,7 @@ function uciExec (commands) {
       case 'bench':
       case 'h': {
 
-        bench(uciGetInt(tokens, cmd, 0));
+        await bench(uciGetInt(tokens, cmd, 0));
         break;
         
       }
@@ -332,7 +341,7 @@ function uciExec (commands) {
           break;
         }
 
-        datagen(tokens[1], target);
+        await datagen(tokens[1], target);
 
         break;
 


### PR DESCRIPTION
## Problem

The UCI `stop` command is a no-op (`case 'stop'` does nothing), and `go()` (the iterative-deepening loop) runs fully synchronously with no yield point back to the event loop. If a search is started with `go depth N` and no `movetime`/`nodes`/`wtime`+`btime` limit, `stop` never interrupts it — the engine keeps searching to the requested depth regardless of how many `stop` commands are sent. A new `position`/`go` doesn't cancel the previous search either; it just waits for it to finish first.

## Cause

1. `checkTime()` only checks `statsMoveTime`/`statsMaxNodes`, which stay `0` when only `depth` is given — so it never sets `statsTimeOut`.
2. Even with a stop flag, `go()` is fully synchronous, so an incoming `stop` message can't be processed until `go()` itself returns.

## Fix

- Added `statsStop` / `statsSearching` flags.
- `checkTime()` now checks `statsStop` unconditionally, independent of `statsBestMove` (so a search can be aborted before any move is found).
- `go()` is now `async`: it awaits the previous search's completion (`statsSearching`) before resetting state, and yields to the event loop between aspiration-window retries and between iterative-deepening depths, checking `statsStop` at each point. 
- `case 'stop'`, `case 'go'`, `case 'position'` set `statsStop = 1` when a search is active.
- `uciExec`, `bench`, `dgPlayGame`/`datagen`, and the Node CLI argv loop are updated to `await` the now-async call chain.

## Example
[ChessAdvisor](http://chesshelp.intsystem.org/) - select Lozza.js in engine settings (as default at now). Search stops on the UCI `stop` command — before starting a new analysis, when switching engines, or when disabling the Recommendation  panel.